### PR TITLE
Refactor product sync orchestration

### DIFF
--- a/app/Console/Commands/SyncShopifyProducts.php
+++ b/app/Console/Commands/SyncShopifyProducts.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Services\ShopifyService;
+use App\Services\ProductService;
 use Illuminate\Console\Command;
 
 class SyncShopifyProducts extends Command
@@ -29,11 +29,11 @@ class SyncShopifyProducts extends Command
         $this->info('🔄 Starting Shopify products sync...');
         
         try {
-            $shopifyService = app(ShopifyService::class);
+            $productService = app(ProductService::class);
             
             $this->line('📡 Fetching products from Shopify...');
             
-            $result = $shopifyService->sync();
+            $result = $productService->syncFromShopify();
             
             $this->newLine();
             $this->info('✅ Sync completed successfully!');

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,20 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Repositories\ProductRepository;
-use App\Services\ShopifyService;
+use App\Services\ProductService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class ProductController extends Controller
 {
-    private ProductRepository $productRepository;
-    private ShopifyService $shopifyService;
-
-    public function __construct(ProductRepository $productRepository, ShopifyService $shopifyService)
+    public function __construct(private ProductService $productService)
     {
-        $this->productRepository = $productRepository;
-        $this->shopifyService = $shopifyService;
     }
 
     /**
@@ -37,7 +31,7 @@ class ProductController extends Controller
                 $perPage = 100;
             }
             
-            $products = $this->productRepository->listPaginated($perPage);
+            $products = $this->productService->listPaginated($perPage);
             
             return response()->json([
                 'data' => $products->items(),
@@ -75,7 +69,7 @@ class ProductController extends Controller
     public function sync(): JsonResponse
     {
         try {
-            $result = $this->shopifyService->sync();
+            $result = $this->productService->syncFromShopify();
             
             return response()->json($result);
         } catch (\Exception $e) {
@@ -94,7 +88,7 @@ class ProductController extends Controller
     public function clear(): JsonResponse
     {
         try {
-            $count = $this->productRepository->clear();
+            $count = $this->productService->clear();
             
             return response()->json([
                 'message' => 'All products cleared successfully',

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\ProductRepository;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Log;
+
+class ProductService
+{
+    public function __construct(
+        private ProductRepository $productRepository,
+        private ShopifyService $shopifyService,
+    ) {
+    }
+
+    public function listPaginated(int $perPage = 10): LengthAwarePaginator
+    {
+        return $this->productRepository->listPaginated($perPage);
+    }
+
+    public function clear(): int
+    {
+        return $this->productRepository->clear();
+    }
+
+    public function syncFromShopify(): array
+    {
+        try {
+            $products = $this->shopifyService->fetchProducts();
+            $syncedCount = 0;
+            $skippedCount = 0;
+
+            foreach ($products as $productData) {
+                if ($this->processProduct($productData)) {
+                    $syncedCount++;
+                } else {
+                    $skippedCount++;
+                }
+            }
+
+            Log::info('Product sync completed', [
+                'synced_count' => $syncedCount,
+                'skipped_count' => $skippedCount,
+                'total_processed' => count($products),
+            ]);
+
+            return [
+                'synced' => $syncedCount,
+                'skipped' => $skippedCount,
+                'total' => count($products),
+            ];
+        } catch (\Exception $e) {
+            Log::error('Failed to sync products', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new \Exception('Failed to sync products: ' . $e->getMessage());
+        }
+    }
+
+    private function processProduct(array $productData): bool
+    {
+        $shopifyId = $productData['id'] ?? null;
+
+        if (!$shopifyId) {
+            Log::warning('Product data missing ID, skipping', ['product' => $productData]);
+
+            return false;
+        }
+
+        $title = $productData['title'] ?? 'Untitled Product';
+        $variant = $this->extractVariantData($productData);
+
+        $this->productRepository->upsert([
+            'shopify_id' => (string) $shopifyId,
+            'title' => $title,
+            'price' => $variant['price'],
+            'stock' => $variant['stock'],
+        ]);
+
+        Log::debug('Product upserted', [
+            'shopify_id' => $shopifyId,
+            'title' => $title,
+            'price' => $variant['price'],
+            'stock' => $variant['stock'],
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @return array{price: float, stock: int}
+     */
+    private function extractVariantData(array $product): array
+    {
+        $price = 0.0;
+        $stock = 0;
+
+        if (!empty($product['variants'])) {
+            $firstVariant = $product['variants'][0];
+            $price = (float) ($firstVariant['price'] ?? 0);
+            $stock = (int) ($firstVariant['inventory_quantity'] ?? 0);
+        }
+
+        return ['price' => $price, 'stock' => $stock];
+    }
+}

--- a/app/Services/ShopifyService.php
+++ b/app/Services/ShopifyService.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use App\Repositories\ProductRepository;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Log;
@@ -10,32 +9,27 @@ use Illuminate\Support\Facades\Log;
 class ShopifyService
 {
     private Client $httpClient;
-    private ProductRepository $productRepository;
     private string $shopDomain;
     private string $accessToken;
     private string $apiVersion;
 
     /**
      * @param Client|null $httpClient Optional HTTP client for dependency injection
-     * @param ProductRepository|null $productRepository Optional product repository for dependency injection
      */
-    public function __construct(?Client $httpClient = null, ?ProductRepository $productRepository = null)
+    public function __construct(?Client $httpClient = null)
     {
-        // Get Shopify credentials from configuration (works with config:cache)
         $shopDomain = config('services.shopify.shop');
         $accessToken = config('services.shopify.access_token');
         $apiVersion = config('services.shopify.api_version', '2025-07');
-        
+
         if (!$shopDomain || !$accessToken) {
             throw new \RuntimeException('Shopify credentials are required. Please set SHOPIFY_SHOP and SHOPIFY_ACCESS_TOKEN environment variables.');
         }
 
-        // Assign to typed properties only after validation
         $this->shopDomain = $shopDomain;
         $this->accessToken = $accessToken;
         $this->apiVersion = $apiVersion;
 
-        // Initialize HTTP client with default headers and timeout if not provided
         $this->httpClient = $httpClient ?? new Client([
             'headers' => [
                 'X-Shopify-Access-Token' => $this->accessToken,
@@ -44,8 +38,6 @@ class ShopifyService
             'timeout' => 30,
         ]);
 
-        $this->productRepository = $productRepository ?? new ProductRepository();
-        
         Log::info('ShopifyService initialized', [
             'shop' => $this->shopDomain,
             'api_version' => $this->apiVersion
@@ -53,67 +45,15 @@ class ShopifyService
     }
 
     /**
-     * Sync products from Shopify API
-     * 
-     * @return array JSON response with sync count and skip count
-     */
-    public function sync(): array
-    {
-        try {
-            $products = $this->fetchProducts();
-            $syncedCount = 0;
-            $skippedCount = 0;
-
-            foreach ($products as $productData) {
-                $wasProcessed = $this->upsertProduct($productData);
-                if ($wasProcessed) {
-                    $syncedCount++;
-                } else {
-                    $skippedCount++;
-                }
-            }
-
-            Log::info('Product sync completed', [
-                'synced_count' => $syncedCount,
-                'skipped_count' => $skippedCount,
-                'total_processed' => count($products)
-            ]);
-
-            return [
-                'synced' => $syncedCount,
-                'skipped' => $skippedCount,
-                'total' => count($products)
-            ];
-
-        } catch (\Exception $e) {
-            Log::error('Failed to sync products', [
-                'error' => $e->getMessage()
-            ]);
-
-            throw new \Exception('Failed to sync products: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Build the Shopify products API URL
-     *
-     * @return string
-     */
-    private function buildProductsUrl(): string
-    {
-        return "https://{$this->shopDomain}.myshopify.com/admin/api/{$this->apiVersion}/products.json";
-    }
-
-    /**
      * Fetch products from Shopify Admin REST API
-     * 
+     *
      * @return array Array of product data from Shopify
      */
-    private function fetchProducts(): array
+    public function fetchProducts(): array
     {
         try {
             $url = $this->buildProductsUrl();
-            
+
             $response = $this->httpClient->get($url, [
                 'headers' => [
                     'X-Shopify-Access-Token' => $this->accessToken,
@@ -122,7 +62,7 @@ class ShopifyService
             ]);
 
             $data = json_decode($response->getBody()->getContents(), true);
-            
+
             return $data['products'] ?? [];
 
         } catch (RequestException $e) {
@@ -130,65 +70,16 @@ class ShopifyService
                 'error' => $e->getMessage(),
                 'shop' => $this->shopDomain
             ]);
-            
+
             throw new \Exception('Failed to fetch products from Shopify: ' . $e->getMessage());
         }
     }
 
     /**
-     * Parse variant data from a product
-     *
-     * @param array $product
-     * @return array{price: float, stock: int}
+     * Build the Shopify products API URL
      */
-    private function parseVariant(array $product): array
+    private function buildProductsUrl(): string
     {
-        $price = 0.0;
-        $stock = 0;
-
-        // Get price from first variant if available
-        if (isset($product['variants']) && !empty($product['variants'])) {
-            $firstVariant = $product['variants'][0];
-            $price = (float) ($firstVariant['price'] ?? 0);
-            $stock = (int) ($firstVariant['inventory_quantity'] ?? 0);
-        }
-
-        return ['price' => $price, 'stock' => $stock];
-    }
-
-    /**
-     * Upsert product into database by shopify_id
-     * 
-     * @param array $productData Product data from Shopify or mock
-     * @return bool True if product was successfully processed, false if skipped
-     */
-    private function upsertProduct(array $productData): bool
-    {
-        $shopifyId = $productData['id'] ?? null;
-        
-        if (!$shopifyId) {
-            Log::warning('Product data missing ID, skipping', ['product' => $productData]);
-            return false;
-        }
-
-        // Extract relevant data from Shopify product structure
-        $title = $productData['title'] ?? 'Untitled Product';
-        $variant = $this->parseVariant($productData);
-
-        $this->productRepository->upsert([
-            'shopify_id' => (string) $shopifyId,
-            'title' => $title,
-            'price' => $variant['price'],
-            'stock' => $variant['stock'],
-        ]);
-
-        Log::debug('Product upserted', [
-            'shopify_id' => $shopifyId,
-            'title' => $title,
-            'price' => $variant['price'],
-            'stock' => $variant['stock']
-        ]);
-        
-        return true;
+        return "https://{$this->shopDomain}.myshopify.com/admin/api/{$this->apiVersion}/products.json";
     }
 }

--- a/tests/Unit/ProductControllerTest.php
+++ b/tests/Unit/ProductControllerTest.php
@@ -3,8 +3,7 @@
 namespace Tests\Unit;
 
 use App\Http\Controllers\ProductController;
-use App\Repositories\ProductRepository;
-use App\Services\ShopifyService;
+use App\Services\ProductService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -15,17 +14,15 @@ use Tests\TestCase;
 class ProductControllerTest extends TestCase
 {
 
-    private $mockProductRepository;
-    private $mockShopifyService;
+    private $mockProductService;
     private ProductController $controller;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
-        $this->mockProductRepository = Mockery::mock(ProductRepository::class);
-        $this->mockShopifyService = Mockery::mock(ShopifyService::class);
-        $this->controller = new ProductController($this->mockProductRepository, $this->mockShopifyService);
+
+        $this->mockProductService = Mockery::mock(ProductService::class);
+        $this->controller = new ProductController($this->mockProductService);
     }
 
     protected function tearDown(): void
@@ -62,7 +59,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->with(1)->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->once()
             ->with(15)
@@ -102,7 +99,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->once()
             ->with(10)  // Default per_page is 10, not 15
@@ -153,7 +150,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->once()
             ->with(10)  // Default per_page is 10, not 15
@@ -189,7 +186,7 @@ class ProductControllerTest extends TestCase
         // Arrange
         $exceptionMessage = 'Database connection failed';
         
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->once()
             ->andThrow(new \Exception($exceptionMessage));
@@ -220,8 +217,8 @@ class ProductControllerTest extends TestCase
             'total' => 6
         ];
 
-        $this->mockShopifyService
-            ->shouldReceive('sync')
+        $this->mockProductService
+            ->shouldReceive('syncFromShopify')
             ->once()
             ->andReturn($syncResult);
 
@@ -245,8 +242,8 @@ class ProductControllerTest extends TestCase
         // Arrange
         $exceptionMessage = 'Shopify API connection failed';
         
-        $this->mockShopifyService
-            ->shouldReceive('sync')
+        $this->mockProductService
+            ->shouldReceive('syncFromShopify')
             ->once()
             ->andThrow(new \Exception($exceptionMessage));
 
@@ -268,8 +265,8 @@ class ProductControllerTest extends TestCase
     public function sync_has_correct_error_json_structure()
     {
         // Arrange
-        $this->mockShopifyService
-            ->shouldReceive('sync')
+        $this->mockProductService
+            ->shouldReceive('syncFromShopify')
             ->once()
             ->andThrow(new \Exception('Test error'));
 
@@ -289,8 +286,8 @@ class ProductControllerTest extends TestCase
     public function sync_handles_runtime_exception()
     {
         // Arrange
-        $this->mockShopifyService
-            ->shouldReceive('sync')
+        $this->mockProductService
+            ->shouldReceive('syncFromShopify')
             ->once()
             ->andThrow(new \RuntimeException('Configuration error'));
 
@@ -315,8 +312,8 @@ class ProductControllerTest extends TestCase
             'total' => 0
         ];
 
-        $this->mockShopifyService
-            ->shouldReceive('sync')
+        $this->mockProductService
+            ->shouldReceive('syncFromShopify')
             ->once()
             ->andReturn($syncResult);
 
@@ -338,7 +335,7 @@ class ProductControllerTest extends TestCase
         // Arrange
         $clearedCount = 5;
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('clear')
             ->once()
             ->andReturn($clearedCount);
@@ -363,7 +360,7 @@ class ProductControllerTest extends TestCase
         // Arrange
         $clearedCount = 0;
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('clear')
             ->once()
             ->andReturn($clearedCount);
@@ -385,7 +382,7 @@ class ProductControllerTest extends TestCase
         // Arrange
         $exceptionMessage = 'Database connection failed';
         
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('clear')
             ->once()
             ->andThrow(new \Exception($exceptionMessage));
@@ -408,7 +405,7 @@ class ProductControllerTest extends TestCase
     public function clear_has_correct_json_structure()
     {
         // Arrange
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('clear')
             ->once()
             ->andReturn(3);
@@ -442,7 +439,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->with(10) // Should be corrected to 10, not the invalid value
             ->once()
@@ -478,7 +475,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->with(100) // Should be capped at 100, not the invalid value
             ->once()
@@ -514,7 +511,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->with(10) // Should be corrected to 10, not 0
             ->once()
@@ -550,7 +547,7 @@ class ProductControllerTest extends TestCase
         $mockPaginator->shouldReceive('nextPageUrl')->andReturn(null);
         $mockPaginator->shouldReceive('url')->andReturn('http://localhost/api/v1/products?page=1');
 
-        $this->mockProductRepository
+        $this->mockProductService
             ->shouldReceive('listPaginated')
             ->with(25) // Should use the exact valid value
             ->once()

--- a/tests/Unit/ProductServiceTest.php
+++ b/tests/Unit/ProductServiceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Repositories\ProductRepository;
+use App\Services\ProductService;
+use App\Services\ShopifyService;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ProductServiceTest extends TestCase
+{
+    private $mockProductRepository;
+    private $mockShopifyService;
+    private ProductService $productService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockProductRepository = Mockery::mock(ProductRepository::class);
+        $this->mockShopifyService = Mockery::mock(ShopifyService::class);
+        $this->productService = new ProductService($this->mockProductRepository, $this->mockShopifyService);
+
+        Log::shouldReceive('info')->zeroOrMoreTimes();
+        Log::shouldReceive('debug')->zeroOrMoreTimes();
+        Log::shouldReceive('error')->zeroOrMoreTimes();
+        Log::shouldReceive('warning')->zeroOrMoreTimes();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_lists_products_using_repository()
+    {
+        $mockPaginator = Mockery::mock(LengthAwarePaginator::class);
+
+        $this->mockProductRepository
+            ->shouldReceive('listPaginated')
+            ->once()
+            ->with(25)
+            ->andReturn($mockPaginator);
+
+        $result = $this->productService->listPaginated(25);
+
+        $this->assertSame($mockPaginator, $result);
+    }
+
+    #[Test]
+    public function it_clears_products_via_repository()
+    {
+        $this->mockProductRepository
+            ->shouldReceive('clear')
+            ->once()
+            ->andReturn(7);
+
+        $cleared = $this->productService->clear();
+
+        $this->assertSame(7, $cleared);
+    }
+
+    #[Test]
+    public function it_syncs_products_successfully()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => '999888777',
+                    'title' => 'Test API Product',
+                    'variants' => [
+                        ['price' => 199.99, 'inventory_quantity' => 5],
+                    ],
+                ],
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '999888777',
+                'title' => 'Test API Product',
+                'price' => 199.99,
+                'stock' => 5,
+            ]);
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(1, $result['synced']);
+        $this->assertEquals(0, $result['skipped']);
+        $this->assertEquals(1, $result['total']);
+    }
+
+    #[Test]
+    public function it_handles_shopify_service_exceptions()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andThrow(new \Exception('Shopify API connection failed'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to sync products: Shopify API connection failed');
+
+        $this->productService->syncFromShopify();
+    }
+
+    #[Test]
+    public function it_handles_empty_products_response()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([]);
+
+        $this->mockProductRepository
+            ->shouldNotReceive('upsert');
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(0, $result['synced']);
+        $this->assertEquals(0, $result['skipped']);
+        $this->assertEquals(0, $result['total']);
+    }
+
+    #[Test]
+    public function it_handles_products_without_variants()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => '999888777',
+                    'title' => 'Product Without Variants',
+                ],
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '999888777',
+                'title' => 'Product Without Variants',
+                'price' => 0.0,
+                'stock' => 0,
+            ]);
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(1, $result['synced']);
+        $this->assertEquals(0, $result['skipped']);
+        $this->assertEquals(1, $result['total']);
+    }
+
+    #[Test]
+    public function it_handles_products_with_missing_title()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => '999888777',
+                    'variants' => [
+                        ['price' => '99.99', 'inventory_quantity' => 10],
+                    ],
+                ],
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '999888777',
+                'title' => 'Untitled Product',
+                'price' => 99.99,
+                'stock' => 10,
+            ]);
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(1, $result['synced']);
+        $this->assertEquals(0, $result['skipped']);
+        $this->assertEquals(1, $result['total']);
+    }
+
+    #[Test]
+    public function it_skips_products_without_id()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([
+                [
+                    'title' => 'Product Without ID',
+                    'variants' => [['price' => '99.99', 'inventory_quantity' => 10]],
+                ],
+            ]);
+
+        $this->mockProductRepository
+            ->shouldNotReceive('upsert');
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(0, $result['synced']);
+        $this->assertEquals(1, $result['skipped']);
+        $this->assertEquals(1, $result['total']);
+    }
+
+    #[Test]
+    public function it_handles_mixed_valid_and_invalid_products()
+    {
+        $this->mockShopifyService
+            ->shouldReceive('fetchProducts')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => '111111111',
+                    'title' => 'Valid Product 1',
+                    'variants' => [['price' => '10.00', 'inventory_quantity' => 5]],
+                ],
+                ['title' => 'Invalid Product - No ID'],
+                [
+                    'id' => '222222222',
+                    'title' => 'Valid Product 2',
+                    'variants' => [['price' => '20.00', 'inventory_quantity' => 10]],
+                ],
+                ['title' => 'Another Invalid Product'],
+                [
+                    'id' => '333333333',
+                    'title' => 'Valid Product 3',
+                ],
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '111111111',
+                'title' => 'Valid Product 1',
+                'price' => 10.0,
+                'stock' => 5,
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '222222222',
+                'title' => 'Valid Product 2',
+                'price' => 20.0,
+                'stock' => 10,
+            ]);
+
+        $this->mockProductRepository
+            ->shouldReceive('upsert')
+            ->once()
+            ->with([
+                'shopify_id' => '333333333',
+                'title' => 'Valid Product 3',
+                'price' => 0.0,
+                'stock' => 0,
+            ]);
+
+        $result = $this->productService->syncFromShopify();
+
+        $this->assertEquals(3, $result['synced']);
+        $this->assertEquals(2, $result['skipped']);
+        $this->assertEquals(5, $result['total']);
+    }
+}

--- a/tests/Unit/ShopifyServiceTest.php
+++ b/tests/Unit/ShopifyServiceTest.php
@@ -2,424 +2,151 @@
 
 namespace Tests\Unit;
 
-use App\Repositories\ProductRepository;
 use App\Services\ShopifyService;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Log;
-use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ShopifyServiceTest extends TestCase
 {
-    private $mockProductRepository;
+    private $originalShop;
+    private $originalAccessToken;
+    private $originalApiVersion;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
-        $this->mockProductRepository = Mockery::mock(ProductRepository::class);
-        
-        // Mock Log facade for all tests
+
+        $this->originalShop = config('services.shopify.shop');
+        $this->originalAccessToken = config('services.shopify.access_token');
+        $this->originalApiVersion = config('services.shopify.api_version');
+
         Log::shouldReceive('info')->zeroOrMoreTimes();
-        Log::shouldReceive('debug')->zeroOrMoreTimes();
         Log::shouldReceive('error')->zeroOrMoreTimes();
-        Log::shouldReceive('warning')->zeroOrMoreTimes();
     }
 
     protected function tearDown(): void
     {
-        Mockery::close();
+        config([
+            'services.shopify.shop' => $this->originalShop,
+            'services.shopify.access_token' => $this->originalAccessToken,
+            'services.shopify.api_version' => $this->originalApiVersion,
+        ]);
+
         parent::tearDown();
     }
 
     #[Test]
     public function it_can_be_instantiated()
     {
-        $service = new ShopifyService(null, $this->mockProductRepository);
-        
+        $service = new ShopifyService();
+
         $this->assertInstanceOf(ShopifyService::class, $service);
     }
 
     #[Test]
-    public function it_syncs_products_successfully()
+    public function it_fetches_products_successfully()
     {
-        // Product Data
-        $productData = [
-            'shopify_id' => '999888777',
-            'title' => 'Test API Product',
-            'price' => 199.99,
-            'stock' => 5
-        ];
-
-        // Arrange
         $mockResponse = json_encode([
             'products' => [
-                [
-                    'id' => $productData['shopify_id'],
-                    'title' => $productData['title'],
-                    'variants' => [
-                        [
-                            'price' => $productData['price'],
-                            'inventory_quantity' => $productData['stock']
-                        ]
-                    ]
-                ]
-            ]
+                ['id' => '1', 'title' => 'Test Product'],
+            ],
         ]);
 
         $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
+            new Response(200, [], $mockResponse),
         ]);
 
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->once()
-            ->with($productData);
+        $service = new ShopifyService($client);
 
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
+        $products = $service->fetchProducts();
 
-        // Assert
-        $this->assertEquals(1, $result['synced']);
-        $this->assertEquals(0, $result['skipped']);
-        $this->assertEquals(1, $result['total']);
+        $this->assertCount(1, $products);
+        $this->assertSame('Test Product', $products[0]['title']);
     }
 
     #[Test]
     public function it_handles_api_request_exceptions()
     {
-        // Arrange
         $mock = new MockHandler([
-            new RequestException('Error Communicating with Server', new Request('GET', 'test'))
+            new RequestException('Error Communicating with Server', new Request('GET', 'test')),
         ]);
 
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        // Act & Assert
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        
+        $service = new ShopifyService($client);
+
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Failed to sync products');
-        
-        $service->sync();
-    }
+        $this->expectExceptionMessage('Failed to fetch products from Shopify: Error Communicating with Server');
 
-    #[Test]
-    public function it_handles_empty_products_response()
-    {
-        // Arrange
-        $mockResponse = json_encode(['products' => []]);
-
-        $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
-        ]);
-
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
-
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
-
-        // Assert
-        $this->assertEquals(0, $result['synced']);
-        $this->assertEquals(0, $result['skipped']);
-        $this->assertEquals(0, $result['total']);
-    }
-
-
-
-
-
-
-
-
-    #[Test]
-    public function it_handles_products_without_variants()
-    {
-        // Arrange
-        $mockResponse = json_encode([
-            'products' => [
-                [
-                    'id' => '999888777',
-                    'title' => 'Product Without Variants'
-                    // No variants field
-                ]
-            ]
-        ]);
-
-        $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
-        ]);
-
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
-
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->once()
-            ->with([
-                'shopify_id' => '999888777',
-                'title' => 'Product Without Variants',
-                'price' => 0,
-                'stock' => 0
-            ]);
-
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
-
-        // Assert
-        $this->assertEquals(1, $result['synced']);
-        $this->assertEquals(0, $result['skipped']);
-        $this->assertEquals(1, $result['total']);
-    }
-
-    #[Test]
-    public function it_handles_products_with_missing_title()
-    {
-        // Arrange
-        $mockResponse = json_encode([
-            'products' => [
-                [
-                    'id' => '999888777',
-                    'variants' => [['price' => '99.99', 'inventory_quantity' => 10]]
-                    // No title field
-                ]
-            ]
-        ]);
-
-        $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
-        ]);
-
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
-
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->once()
-            ->with([
-                'shopify_id' => '999888777',
-                'title' => 'Untitled Product',
-                'price' => 99.99,
-                'stock' => 10
-            ]);
-
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
-
-        // Assert
-        $this->assertEquals(1, $result['synced']);
-        $this->assertEquals(0, $result['skipped']);
-        $this->assertEquals(1, $result['total']);
-    }
-
-    #[Test]
-    public function it_skips_products_without_id()
-    {
-        // Arrange
-        $mockResponse = json_encode([
-            'products' => [
-                [
-                    'title' => 'Product Without ID',
-                    'variants' => [['price' => '99.99', 'inventory_quantity' => 10]]
-                    // No id field
-                ]
-            ]
-        ]);
-
-        $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
-        ]);
-
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
-
-        // Repository should not be called since product has no ID
-        $this->mockProductRepository
-            ->shouldNotReceive('upsert');
-
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
-
-        // Assert
-        $this->assertEquals(0, $result['synced']);
-        $this->assertEquals(1, $result['skipped']);
-        $this->assertEquals(1, $result['total']);
-    }
-
-
-    #[Test]
-    public function it_handles_mixed_valid_and_invalid_products()
-    {
-        // Arrange
-        $mockResponse = json_encode([
-            'products' => [
-                [
-                    'id' => '111111111',
-                    'title' => 'Valid Product 1',
-                    'variants' => [['price' => '10.00', 'inventory_quantity' => 5]]
-                ],
-                ['title' => 'Invalid Product - No ID'],
-                [
-                    'id' => '222222222',
-                    'title' => 'Valid Product 2',
-                    'variants' => [['price' => '20.00', 'inventory_quantity' => 10]]
-                ],
-                ['title' => 'Another Invalid Product'],
-                [
-                    'id' => '333333333',
-                    'title' => 'Valid Product 3'
-                    // No variants
-                ]
-            ]
-        ]);
-
-        $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
-        ]);
-
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
-
-        // Expect upsert to be called 3 times for valid products
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->times(3);
-
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->with([
-                'shopify_id' => '111111111',
-                'title' => 'Valid Product 1',
-                'price' => 10.00,
-                'stock' => 5
-            ]);
-
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->with([
-                'shopify_id' => '222222222',
-                'title' => 'Valid Product 2',
-                'price' => 20.00,
-                'stock' => 10
-            ]);
-
-        $this->mockProductRepository
-            ->shouldReceive('upsert')
-            ->with([
-                'shopify_id' => '333333333',
-                'title' => 'Valid Product 3',
-                'price' => 0,
-                'stock' => 0
-            ]);
-
-        // Act
-        $service = new ShopifyService($client, $this->mockProductRepository);
-        $result = $service->sync();
-
-        // Assert
-        $this->assertEquals(3, $result['synced']); // 3 valid products
-        $this->assertEquals(2, $result['skipped']); // 2 invalid products
-        $this->assertEquals(5, $result['total']); // 5 total products
-    }
-
-    #[Test]
-    public function it_validates_shopify_credentials_in_constructor()
-    {
-        // Test 1: Constructor should succeed with valid credentials
-        $service = new ShopifyService(null, $this->mockProductRepository);
-        $this->assertInstanceOf(ShopifyService::class, $service);
+        $service->fetchProducts();
     }
 
     #[Test]
     public function it_throws_exception_when_shop_domain_is_missing()
     {
-        // Arrange - Temporarily clear the shop configuration
         config(['services.shopify.shop' => null]);
-        
-        // Act & Assert - Constructor should throw RuntimeException
+
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Shopify credentials are required. Please set SHOPIFY_SHOP and SHOPIFY_ACCESS_TOKEN environment variables.');
-        
-        new ShopifyService(null, $this->mockProductRepository);
+
+        new ShopifyService();
     }
 
     #[Test]
     public function it_throws_exception_when_access_token_is_missing()
     {
-        // Arrange - Temporarily clear the access token configuration
         config(['services.shopify.access_token' => null]);
-        
-        // Act & Assert - Constructor should throw RuntimeException
+
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Shopify credentials are required. Please set SHOPIFY_SHOP and SHOPIFY_ACCESS_TOKEN environment variables.');
-        
-        new ShopifyService(null, $this->mockProductRepository);
+
+        new ShopifyService();
     }
 
     #[Test]
     public function it_throws_exception_when_both_credentials_are_missing()
     {
-        // Arrange - Temporarily clear both configurations
         config([
             'services.shopify.shop' => null,
-            'services.shopify.access_token' => null
+            'services.shopify.access_token' => null,
         ]);
-        
-        // Act & Assert - Constructor should throw RuntimeException
+
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Shopify credentials are required. Please set SHOPIFY_SHOP and SHOPIFY_ACCESS_TOKEN environment variables.');
-        
-        new ShopifyService(null, $this->mockProductRepository);
+
+        new ShopifyService();
     }
 
     #[Test]
-    public function it_configures_http_client_with_correct_headers()
+    public function it_allows_custom_http_client_configuration()
     {
-        // Arrange - Ensure we have test credentials configured
-        // (these are already set in phpunit.xml, but we can override if needed)
         config([
             'services.shopify.shop' => 'test-shop',
-            'services.shopify.access_token' => 'test-access-token'
+            'services.shopify.access_token' => 'test-access-token',
         ]);
-        
-        // Create a mock response to trigger HTTP request and inspect headers
-        $mockResponse = json_encode(['products' => []]);
-        
+
         $mock = new MockHandler([
-            new Response(200, [], $mockResponse)
+            new Response(200, [], json_encode(['products' => []])),
         ]);
-        
+
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
-        
-        // Create service with our mock client
-        $serviceWithMockClient = new ShopifyService($client, $this->mockProductRepository);
-        
-        // Act - This will trigger the HTTP request
-        $result = $serviceWithMockClient->sync();
-        
-        // Assert - Check that the mock was called (implies headers were set correctly)
-        $this->assertEquals(0, $result['synced']);
-        $this->assertEquals(0, $result['skipped']);
-        $this->assertEquals(0, $result['total']);
-        
-        // The fact that no exception was thrown and the service worked correctly
-        // indicates that the HTTP client was configured properly with headers
+
+        $service = new ShopifyService($client);
+
+        $products = $service->fetchProducts();
+
+        $this->assertSame([], $products);
     }
 }


### PR DESCRIPTION
## Summary
- add a ProductService layer to orchestrate Shopify fetches with repository persistence and adopt it in the HTTP controller and console command
- slim ShopifyService to focus on API access while exposing fetchProducts for consumers
- refresh unit and feature tests to cover the new ProductService workflow and updated wiring

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68c99dd5f0e483339a9997eb3810c893